### PR TITLE
option to call ms-skype instead of linphone

### DIFF
--- a/org-dial.el
+++ b/org-dial.el
@@ -38,6 +38,7 @@
   "Options about softphone support."
   :group 'org)
 
+;; Replace "linphonecsh dial " with "Skype.exe /callto:" to make this work with Skype on Microsoft Windows
 (defcustom org-dial-program "linphonecsh dial "
   "Name of the softphone executable used to dial a phone number in a `tel:' link."
   :type '(string)


### PR DESCRIPTION
Adds this comment to org-dial.el 
;; Replace "linphonecsh dial " with "Skype.exe /callto:" to make this work with Skype on Microsoft Windows